### PR TITLE
Remove debug logs which slipped through

### DIFF
--- a/lib/charms/grafana_k8s/v1/grafana_source.py
+++ b/lib/charms/grafana_k8s/v1/grafana_source.py
@@ -247,13 +247,6 @@ class GrafanaSourceProvider(ProviderBase):
         if not self.charm.unit.is_leader():
             return
 
-        logger.info("RELATION APP: {}".format(event.relation.app))
-        logger.info("RELATION APP: {}".format(dir(event.relation.app)))
-
-        for u in event.relation.units:
-            logger.info("UNIT: {}".format(u))
-            logger.info("UNIT: {}".format(dir(u)))
-
         rel = event.relation
         data = (
             json.loads(event.relation.data[event.app].get("sources", {}))


### PR DESCRIPTION
Even though the libraries are `v1` as folders, `LIBAPI` should be `0` according to guidance. Update it.

Also, remove some debug logging which slipped through when the patch got split up