### PR TITLE
Lint fixes needed for linting to pass with pyproject.toml and tox.ini

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,15 +1,14 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 type: charm
 bases:
   - build-on:
-    - name: "ubuntu"
-      channel: "20.04"
+      - name: "ubuntu"
+        channel: "20.04"
     run-on:
-    - name: "ubuntu"
-      channel: "20.04"
+      - name: "ubuntu"
+        channel: "20.04"
 parts:
   charm:
     build-packages:
-    - git
+      - git

--- a/config.yaml
+++ b/config.yaml
@@ -1,27 +1,29 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
 options:
-    port:
-        description: The port grafana-k8s will be listening on
-        type: int
-        default: 3000
-    log_level:
-        type: string
-        description: |
-            Logging level for Grafana. Options are “debug”, “info”,
-            “warn”, “error”, and “critical”.
-        default: info
-    admin_user:
-        description: The Grafana administrative user
-        type: string
-        default: admin
-    web_external_url:
-        description: |
-            The URL under which Grafana is externally reachable (for example,
-            if Grafana is served via a reverse proxy).
+  port:
+    description: The port grafana-k8s will be listening on
+    type: int
+    default: 3000
+  log_level:
+    type: string
+    description: |
+      Logging level for Grafana. Options are “debug”, “info”,
+      “warn”, “error”, and “critical”.
+    default: info
+  admin_user:
+    description: The Grafana administrative user
+    type: string
+    default: admin
+  web_external_url:
+    description: |
+      The URL under which Grafana is externally reachable (for example,
+      if Grafana is served via a reverse proxy).
 
-            Used for generating relative and absolute links back to
-            Grafana itself. If the URL has a path portion, it will be used to
-            prefix all HTTP endpoints served by Grafana.
+      Used for generating relative and absolute links back to
+      Grafana itself. If the URL has a path portion, it will be used to
+      prefix all HTTP endpoints served by Grafana.
 
-            If omitted, relevant URL components will be derived automatically.
-        type: string
-        default: ""
+      If omitted, relevant URL components will be derived automatically.
+    type: string
+    default: ""

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1,24 +1,22 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""A library for working with Grafana dashboards for charm authors."""
+
 import base64
 import copy
 import json
 import logging
 import uuid
 import zlib
+from typing import Dict, List, Union
 
 from jinja2 import Template
 from jinja2.exceptions import TemplateSyntaxError
-
-from ops.charm import (
-    CharmBase,
-    CharmEvents,
-    RelationBrokenEvent,
-    RelationChangedEvent,
-)
-from ops.model import Relation, Unit
+from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
 from ops.framework import EventBase, EventSource, StoredState
+from ops.model import Relation, Unit
 from ops.relation import ConsumerBase, ConsumerEvents, ProviderBase
-
-from typing import Dict, List, Union
 
 # The unique Charmhub library identifier, never change it
 LIBID = "c49eb9c7dfef40c7b6235ebd67010a3f"
@@ -34,30 +32,31 @@ logger = logging.getLogger(__name__)
 
 
 class GrafanaDashboardsChanged(EventBase):
-    """Event emitted when Grafana dashboards change"""
+    """Event emitted when Grafana dashboards change."""
 
     def __init__(self, handle, data=None):
         super().__init__(handle)
         self.data = data
 
     def snapshot(self) -> Dict:
-        """Save grafana source information"""
+        """Save grafana source information."""
         return {"data": self.data}
 
     def restore(self, snapshot):
-        """Restore grafana source information"""
+        """Restore grafana source information."""
         self.data = snapshot["data"]
 
 
 class GrafanaDashboardEvents(CharmEvents):
-    """Events raised by :class:`GrafanaSourceEvents`"""
+    """Events raised by :class:`GrafanaSourceEvents`."""
 
     dashboards_changed = EventSource(GrafanaDashboardsChanged)
 
 
 class GrafanaDashboardEvent(EventBase):
-    """Event emitted when Grafana dashboards cannot be resolved so we can
-    set a status on the consumer
+    """Event emitted when Grafana dashboards cannot be resolved.
+
+    Enables us to set a clear status on the consumer.
     """
 
     def __init__(self, handle, error_message: str = "", valid: bool = False):
@@ -66,22 +65,24 @@ class GrafanaDashboardEvent(EventBase):
         self.valid = valid
 
     def snapshot(self) -> Dict:
-        """Save grafana source information"""
+        """Save grafana source information."""
         return {"error_message": self.error_message, "valid": self.valid}
 
     def restore(self, snapshot):
-        """Restore grafana source information"""
+        """Restore grafana source information."""
         self.error_message = snapshot["error_message"]
         self.valid = snapshot["valid"]
 
 
 class GrafanaConsumerEvents(ConsumerEvents):
-    """Events raised by :class:`GrafanaSourceEvents`"""
+    """Events raised by :class:`GrafanaSourceEvents`."""
 
     dashboard_status_changed = EventSource(GrafanaDashboardEvent)
 
 
 class GrafanaDashboardConsumer(ConsumerBase):
+    """A consumer object for Grafana dashboards."""
+
     _stored = StoredState()
     on = GrafanaConsumerEvents()
 
@@ -107,7 +108,6 @@ class GrafanaDashboardConsumer(ConsumerBase):
             self.grafana.add_dashboard(data: str)
 
         Args:
-
             charm: a :class:`CharmBase` object which manages this
                 :class:`GrafanaConsumer` object. Generally this is
                 `self` in the instantiating class.
@@ -127,14 +127,11 @@ class GrafanaDashboardConsumer(ConsumerBase):
             multi: an optional (default `False`) flag to indicate if
                 this object should support interacting with multiple
                 service providers.
-
         """
         super().__init__(charm, name, consumes, multi)
 
         self.charm = charm
-        self._stored.set_default(
-            dashboards={}, dashboard_templates={}, event_relation=None
-        )
+        self._stored.set_default(dashboards={}, dashboard_templates={}, event_relation=None)
         self._stored.event_relation = event_relation
 
         events = self.charm.on[name]
@@ -153,10 +150,10 @@ class GrafanaDashboardConsumer(ConsumerBase):
         )
 
     def add_dashboard(self, data: str, rel_id=None) -> None:
-        """
-        Add a dashboard to Grafana. `data` should be a string representing
-        a jinja template which can be templated with the appropriate
-        `grafana_datasource` and `prometheus_job_name`.
+        """Add a dashboard to Grafana.
+
+        `data` should be a string representing a jinja template which can be templated with the
+        appropriate `grafana_datasource` and `prometheus_job_name`.
         """
         rel = self.framework.model.get_relation(self.name, rel_id)
         rel_id = rel_id if rel_id is not None else rel.id
@@ -172,19 +169,16 @@ class GrafanaDashboardConsumer(ConsumerBase):
             error_message = ("Waiting for a {} relation to send dashboard data").format(
                 self._stored.event_relation
             )
-            self.on.dashboard_status_changed.emit(
-                error_message=error_message, valid=False
-            )
+            self.on.dashboard_status_changed.emit(error_message=error_message, valid=False)
             return
 
         self._update_dashboards(data, rel_id, prom_unit)
 
-    def _on_grafana_dashboard_relation_changed(
-        self, event: RelationChangedEvent
-    ) -> None:
-        """
-        Watch for changes so we know if there's an error to signal back to the
-        parent charm.
+    def _on_grafana_dashboard_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Watch for changes so we know if there's an error to signal back to the parent charm.
+
+        Args:
+            event: The `RelationChangedEvent` that triggered this handler.
         """
         if not self.charm.unit.is_leader():
             return
@@ -213,9 +207,7 @@ class GrafanaDashboardConsumer(ConsumerBase):
                 )
 
     def _update_dashboards(self, data: str, rel_id: int, prom_unit: Unit) -> None:
-        """
-        Update the dashboards in the relation data bucket.
-        """
+        """Update the dashboards in the relation data bucket."""
         if not self.charm.unit.is_leader():
             return
 
@@ -231,10 +223,8 @@ class GrafanaDashboardConsumer(ConsumerBase):
             self.charm.model.uuid,
         )
 
-        prom_query = (
-            "juju_model='{}',juju_model_uuid='{}',juju_application='{}'".format(
-                self.charm.model.name, self.charm.model.uuid, self.charm.app.name
-            )
+        prom_query = "juju_model='{}',juju_model_uuid='{}',juju_application='{}'".format(
+            self.charm.model.name, self.charm.model.uuid, self.charm.app.name
         )
 
         # It's completely ridiculous to add a UUID, but if we don't have some
@@ -320,9 +310,7 @@ class GrafanaDashboardConsumer(ConsumerBase):
     def _check_monitoring_relation(self) -> bool:
         """Check whether an existing monitoring relation exists."""
         return (
-            True
-            if len(self.model.get_relation(self._stored.event_relation).units) == 0
-            else False
+            True if len(self.model.get_relation(self._stored.event_relation).units) == 0 else False
         )
 
     @property
@@ -332,11 +320,13 @@ class GrafanaDashboardConsumer(ConsumerBase):
 
 
 class GrafanaDashboardProvider(ProviderBase):
+    """A provider object for working with Grafana Dashboards."""
+
     on = GrafanaDashboardEvents()
     _stored = StoredState()
 
     def __init__(self, charm: CharmBase, name: str, service: str, version=None) -> None:
-        """A Grafana based Monitoring service consumer
+        """A Grafana based Monitoring service consumer.
 
         Args:
             charm: a :class:`CharmBase` instance that manages this
@@ -366,13 +356,9 @@ class GrafanaDashboardProvider(ProviderBase):
         self.framework.observe(
             events.relation_changed, self._on_grafana_dashboard_relation_changed
         )
-        self.framework.observe(
-            events.relation_broken, self._on_grafana_dashboard_relation_broken
-        )
+        self.framework.observe(events.relation_broken, self._on_grafana_dashboard_relation_broken)
 
-    def _on_grafana_dashboard_relation_changed(
-        self, event: RelationChangedEvent
-    ) -> None:
+    def _on_grafana_dashboard_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle relation changes in related consumers.
 
         If there are changes in relations between Grafana dashboard providers
@@ -418,10 +404,15 @@ class GrafanaDashboardProvider(ProviderBase):
         self._validate_dashboard_data(data, rel)
 
     def _validate_dashboard_data(self, data: Dict, rel: Relation) -> None:
-        """
+        """Validate a given dashboard.
+
         Verify that the passed dashboard data is able to be found in our list
         of datasources and will render. If they do, let the charm know by
         emitting an event.
+
+        Args:
+            data: Dict; The serialised dashboard.
+            rel: Relation; The relation the dashboard is associated with.
         """
         grafana_datasource = self._find_grafana_datasource(data, rel)
         if not grafana_datasource:
@@ -436,16 +427,12 @@ class GrafanaDashboardProvider(ProviderBase):
         # of encoding to byte, compressing with zlib, converting to base64 so it
         # can be converted to JSON, then all the way back
         try:
-            tm = Template(
-                zlib.decompress(base64.b64decode(data["template"].encode())).decode()
-            )
+            tm = Template(zlib.decompress(base64.b64decode(data["template"].encode())).decode())
         except TemplateSyntaxError:
             self._purge_dead_dashboard(rel.id)
             msg = "Cannot add Grafana dashboard. Template is not valid Jinja"
             logger.warning(msg)
-            rel.data[self.charm.app]["event"] = json.dumps(
-                {"errors": msg, "valid": False}
-            )
+            rel.data[self.charm.app]["event"] = json.dumps({"errors": msg, "valid": False})
             return
 
         msg = tm.render(
@@ -464,9 +451,7 @@ class GrafanaDashboardProvider(ProviderBase):
         # send data back to the providing charm so it knows this dashboard is
         # valid now
         if self._stored.invalid_dashboards.pop(rel.id, None):
-            rel.data[self.charm.app]["event"] = json.dumps(
-                {"errors": "", "valid": True}
-            )
+            rel.data[self.charm.app]["event"] = json.dumps({"errors": "", "valid": True})
 
         stored_data = self._stored.dashboards.get(rel.id, {}).get("data", {})
         coerced_data = dict(stored_data) if stored_data else {}
@@ -476,7 +461,8 @@ class GrafanaDashboardProvider(ProviderBase):
             self.on.dashboards_changed.emit()
 
     def _find_grafana_datasource(self, data: Dict, rel: Relation) -> Union[str, None]:
-        """
+        """Find datasources on a given relation for a provider.
+
         Loop through the provider data and try to find a matching datasource. Return it
         if possible, otherwise add it to the list of invalid dashboards.
 
@@ -497,27 +483,31 @@ class GrafanaDashboardProvider(ProviderBase):
         return grafana_datasource
 
     def _check_active_data_sources(self, data: Dict, rel: Relation) -> bool:
-        """
+        """Check for active Grafana dashboards.
+
         A trivial check to see whether there are any active datasources or not, used
-        by both new dashboard additions and trying to restore invalid ones. Returns
-        a :bool:
+        by both new dashboard additions and trying to restore invalid ones.
+
+        Returns: a boolean indicating if there are any active dashboards.
         """
         if not self._stored.active_sources:
             msg = "Cannot add Grafana dashboard. No configured datasources"
             self._stored.invalid_dashboards[rel.id] = data
             self._purge_dead_dashboard(rel.id)
             logger.warning(msg)
-            rel.data[self.charm.app]["event"] = json.dumps(
-                {"errors": msg, "valid": False}
-            )
+            rel.data[self.charm.app]["event"] = json.dumps({"errors": msg, "valid": False})
 
             return False
         return True
 
     def renew_dashboards(self, sources: List) -> None:
-        """
+        """Re-establish dashboards following a change to the relation.
+
         If something changes between this library and a datasource, try to re-establish
-        invalid dashboards and invalidate active ones
+        invalid dashboards and invalidate active ones.
+
+        Args:
+            sources: List; A list of datasources.
         """
         # Cannot nest StoredDict inside StoredList
         self._stored.active_sources = [dict(s) for s in sources]
@@ -552,14 +542,15 @@ class GrafanaDashboardProvider(ProviderBase):
             logger.warning("Could not remove dashboard for relation: {}".format(rel_id))
 
     def _purge_dead_dashboard(self, rel_id: int) -> None:
-        """If an errored dashboard is in stored data, remove it and trigger a deletion"""
+        """If an errored dashboard is in stored data, remove it and trigger a deletion."""
         if self._stored.dashboards.pop(rel_id, None):
             self.on.dashboards_changed.emit()
 
     @property
     def dashboards(self) -> List:
-        """
-        Returns a list of known dashboards
+        """Get a list of known dashboards.
+
+        Returns: a list of known dashboards.
         """
         dashboards = []
         for dash in self._stored.dashboards.values():

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -1,17 +1,16 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""A library for working with Grafana datasources for charm authors."""
+
 import json
 import logging
+from typing import Dict, List, Optional
 
-from ops.charm import (
-    CharmBase,
-    CharmEvents,
-    RelationDepartedEvent,
-    RelationJoinedEvent,
-)
+from ops.charm import CharmBase, CharmEvents, RelationDepartedEvent, RelationJoinedEvent
 from ops.framework import EventBase, EventSource, ObjectEvents, StoredState
 from ops.model import Relation
 from ops.relation import ConsumerBase, ProviderBase
-from typing import Dict, List, Optional
-
 
 # The unique Charmhub library identifier, never change it
 LIBID = "974705adb86f40228298156e34b460dc"
@@ -27,27 +26,29 @@ logger = logging.getLogger(__name__)
 
 
 class SourceFieldsMissingError(Exception):
+    """An exception to indicate there a missing fields from a Grafana datsource definition."""
+
     pass
 
 
 class GrafanaSourcesChanged(EventBase):
-    """Event emitted when Grafana sources change"""
+    """Event emitted when Grafana sources change."""
 
     def __init__(self, handle, data=None):
         super().__init__(handle)
         self.data = data
 
     def snapshot(self) -> Dict:
-        """Save grafana source information"""
+        """Save grafana source information."""
         return {"data": self.data}
 
     def restore(self, snapshot) -> None:
-        """Restore grafana source information"""
+        """Restore grafana source information."""
         self.data = snapshot["data"]
 
 
 class GrafanaSourceEvents(ObjectEvents):
-    """Events raised by :class:`GrafanaSourceEvents`"""
+    """Events raised by :class:`GrafanaSourceEvents."""
 
     # We are emitting multiple events for the same thing due to the way Grafana provisions
     # datasources. There is no "convenient" way to tell Grafana to remove them outside of
@@ -59,6 +60,8 @@ class GrafanaSourceEvents(ObjectEvents):
 
 
 class GrafanaSourceConsumer(ConsumerBase):
+    """A consumer object for Grafana datasources."""
+
     _stored = StoredState()
 
     def __init__(
@@ -90,7 +93,6 @@ class GrafanaSourceConsumer(ConsumerBase):
             )
 
         Args:
-
             charm: a :class:`CharmBase` object which manages this
                 :class:`GrafanaSourceConsumer` object. Generally this is
                 `self` in the instantiating class.
@@ -105,9 +107,9 @@ class GrafanaSourceConsumer(ConsumerBase):
             refresh_event: a :class:`CharmEvents` event on which the IP
                 address should be refreshed in case of pod or
                 machine/VM restart.
-            source_type an optional (default `prometheus`) source type
+            source_type: an optional (default `prometheus`) source type
                 required for Grafana configuration
-            source_port an optional (default `9090`) source port
+            source_port: an optional (default `9090`) source port
                 required for Grafana configuration
             multi: an optional (default `False`) flag to indicate if
                 this object should support interacting with multiple
@@ -125,26 +127,20 @@ class GrafanaSourceConsumer(ConsumerBase):
         self.framework.observe(refresh_event, self._set_unit_ip)
 
     def _set_sources(self, event: RelationJoinedEvent):
-        """
-        On a relation_joined event, inform the provider about the source
-        configuration
-        """
+        """Inform the provider about the source configuration."""
         self._set_unit_ip(event)
 
         if not self.charm.unit.is_leader():
             return
 
         logger.debug("Setting Grafana data sources: %s", self._scrape_data)
-        event.relation.data[self.charm.app]["grafana_source_data"] = json.dumps(
-            self._scrape_data
-        )
+        event.relation.data[self.charm.app]["grafana_source_data"] = json.dumps(self._scrape_data)
 
     @property
     def _scrape_data(self) -> Dict:
         """Generate source metadata.
 
         Returns:
-
             Source configuration data for Grafana.
         """
         data = {
@@ -156,10 +152,10 @@ class GrafanaSourceConsumer(ConsumerBase):
         return data
 
     def _set_unit_ip(self, event: CharmEvents):
-        """Set unit host address
+        """Set unit host address.
 
-        Each time a consumer charm container is restarted it updates its own
-        host address in the unit relation data for the Prometheus provider.
+        Each time a consumer charm container is restarted it updates its own host address in the
+        unit relation data for the Prometheus provider.
         """
         for relation in self.charm.model.relations[self.name]:
             relation.data[self.charm.unit]["grafana_source_host"] = "{}:{}".format(
@@ -169,13 +165,15 @@ class GrafanaSourceConsumer(ConsumerBase):
 
 
 class GrafanaSourceProvider(ProviderBase):
+    """A provider object for working with Grafana datasources."""
+
     on = GrafanaSourceEvents()
     _stored = StoredState()
 
     def __init__(
         self, charm: CharmBase, name: str, service: str, version: Optional[str] = None
     ) -> None:
-        """A Grafana based Monitoring service consumer
+        """A Grafana based Monitoring service consumer.
 
         Args:
             charm: a :class:`CharmBase` instance that manages this
@@ -189,7 +187,6 @@ class GrafanaSourceProvider(ProviderBase):
                 `consumes` argument. Typically this string is just "grafana".
             version: a string providing the semantic version of the Grafana
                 source being provided.
-
         """
         super().__init__(charm, name, service, version)
         self.charm = charm
@@ -200,12 +197,8 @@ class GrafanaSourceProvider(ProviderBase):
             sources_to_delete=set(),
         )
 
-        self.framework.observe(
-            events.relation_changed, self._on_grafana_source_relation_changed
-        )
-        self.framework.observe(
-            events.relation_departed, self._on_grafana_source_relation_departed
-        )
+        self.framework.observe(events.relation_changed, self._on_grafana_source_relation_changed)
+        self.framework.observe(events.relation_departed, self._on_grafana_source_relation_departed)
 
     def _on_grafana_source_relation_changed(self, event: CharmEvents) -> None:
         """Handle relation changes in related consumers.
@@ -235,11 +228,7 @@ class GrafanaSourceProvider(ProviderBase):
         self.on.sources_changed.emit()
 
     def _get_source_config(self, rel: Relation):
-        """
-        Generate configuration from data stored in relation data by
-        consumers which we can pass back to the charm
-        """
-
+        """Generate configuration from data stored in relation data by consumers."""
         source_data = json.loads(rel.data[rel.app].get("grafana_source_data", "{}"))
         if not source_data:
             return
@@ -273,6 +262,7 @@ class GrafanaSourceProvider(ProviderBase):
         Args:
             rel: An `ops.model.Relation` object for which the host name to
                 address mapping is required.
+
         Returns:
             A dictionary that maps unit names to unit addresses for
             the specified relation.
@@ -299,9 +289,9 @@ class GrafanaSourceProvider(ProviderBase):
         self._remove_source_from_datastore(event)
 
     def _remove_source_from_datastore(self, event: RelationDepartedEvent) -> None:
-        """Remove the grafana-source from the datastore. and add the
-        name to the list of sources to remove when a relation is
-        broken.
+        """Remove the grafana-source from the datastore.
+
+        Add the name to the list of sources to remove when a relation is broken.
         """
         rel_id = event.relation.id
         logger.debug("Removing all data for relation: {}".format(rel_id))
@@ -314,7 +304,9 @@ class GrafanaSourceProvider(ProviderBase):
                 self._remove_source(dead_unit["source-name"])
 
                 # Re-update the list of stored sources
-                self._stored.sources[rel_id] = [dict(s) for s in removed_source if s["unit"] != event.unit.name]
+                self._stored.sources[rel_id] = [
+                    dict(s) for s in removed_source if s["unit"] != event.unit.name
+                ]
             else:
                 for host in removed_source:
                     self._remove_source(host["source-name"])
@@ -322,12 +314,12 @@ class GrafanaSourceProvider(ProviderBase):
             self.on.sources_to_delete_changed.emit()
 
     def _remove_source(self, source_name: str) -> None:
-        """Remove a datasource by name"""
+        """Remove a datasource by name."""
         self._stored.sources_to_delete.add(source_name)
 
     @property
     def sources(self) -> List[dict]:
-        """Returns an array of sources the source_provider knows about"""
+        """Returns an array of sources the source_provider knows about."""
         sources = []
         for source in self._stored.sources.values():
             sources.extend([host for host in source])
@@ -335,7 +327,7 @@ class GrafanaSourceProvider(ProviderBase):
         return sources
 
     def update_port(self, relation_name: str, port: int) -> None:
-        """Updates the port grafana-k8s is listening on"""
+        """Updates the port grafana-k8s is listening on."""
         if self.charm.unit.is_leader():
             for relation in self.charm.model.relations[relation_name]:
                 logger.debug("Setting grafana-k8s address data for relation", relation)
@@ -344,7 +336,7 @@ class GrafanaSourceProvider(ProviderBase):
 
     @property
     def sources_to_delete(self) -> List[str]:
-        """Returns an array of source names which have been removed"""
+        """Returns an array of source names which have been removed."""
         sources_to_delete = []
         for source in self._stored.sources_to_delete:
             sources_to_delete.append(source)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,43 +1,44 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
 name: grafana-k8s
 display-name: Grafana
 summary: Data visualization and observability with Grafana
 maintainers:
-    - Ryan Barry <ryan.barry@canonical.com>
+  - Ryan Barry <ryan.barry@canonical.com>
 description: |
-    Grafana provides dashboards for monitoring data and this
-    charm is written to allow for HA on Kubernetes and can take
-    multiple data sources (for example, Prometheus).
+  Grafana provides dashboards for monitoring data and this
+  charm is written to allow for HA on Kubernetes and can take
+  multiple data sources (for example, Prometheus).
 tags:
-    - observability
-    - lma
-    - monitoring
-    - grafana
-    - prometheus
+  - observability
+  - lma
+  - monitoring
+  - grafana
+  - prometheus
 containers:
-    grafana:
-        resource: grafana-image
-        mounts:
-            - storage: database
-              location: /var/lib/grafana
+  grafana:
+    resource: grafana-image
+    mounts:
+      - storage: database
+        location: /var/lib/grafana
 provides:
-    grafana:
-        interface: grafana
-    grafana-source:
-        interface: grafana_datasource
-    grafana-dashboard:
-        interface: grafana_dashboard
+  grafana:
+    interface: grafana
+  grafana-source:
+    interface: grafana_datasource
+  grafana-dashboard:
+    interface: grafana_dashboard
 storage:
-    database:
-        type: filesystem
+  database:
+    type: filesystem
 requires:
-    database:
-        interface: db
-        limit: 1
+  database:
+    interface: db
+    limit: 1
 peers:
-    grafana-peers:
-        interface: grafana_peers
+  grafana-peers:
+    interface: grafana_peers
 resources:
-    grafana-image:
-        type: oci-image
-        description: upstream docker image for Grafana
-
+  grafana-image:
+    type: oci-image
+    description: upstream docker image for Grafana

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,15 +15,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+"""A Kubernetes charm for Grafana."""
+
 import base64
 import configparser
-import logging
 import hashlib
+import logging
 import os
-import yaml
 import zlib
-
 from io import StringIO
+
+import yaml
+from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
+from charms.grafana_k8s.v0.grafana_source import (
+    GrafanaSourceEvents,
+    GrafanaSourceProvider,
+    SourceFieldsMissingError,
+)
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -36,15 +44,7 @@ from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus
 from ops.pebble import ConnectionError, Layer
 
-from charms.grafana_k8s.v0.grafana_source import (
-    GrafanaSourceEvents,
-    GrafanaSourceProvider,
-    SourceFieldsMissingError,
-)
-from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
-
 from grafana_server import Grafana
-
 
 logger = logging.getLogger()
 
@@ -93,9 +93,7 @@ class GrafanaCharm(CharmBase):
         self.framework.observe(self.on.stop, self._on_stop)
 
         # -- grafana_source relation observations
-        self.source_provider = GrafanaSourceProvider(
-            self, "grafana-source", "grafana", VERSION
-        )
+        self.source_provider = GrafanaSourceProvider(self, "grafana-source", "grafana", VERSION)
         self.framework.observe(
             self.source_provider.on.sources_changed,
             self._on_grafana_source_changed,
@@ -114,15 +112,12 @@ class GrafanaCharm(CharmBase):
         )
 
         # -- database relation observations
-        self.framework.observe(
-            self.on["database"].relation_changed, self._on_database_changed
-        )
-        self.framework.observe(
-            self.on["database"].relation_broken, self._on_database_broken
-        )
+        self.framework.observe(self.on["database"].relation_changed, self._on_database_changed)
+        self.framework.observe(self.on["database"].relation_broken, self._on_database_broken)
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
-        """
+        """Event handler for the config-changed event.
+
         If the configuration is changed, update the variables we know about and
         restart the services. We don't know specifically whether it's a new install,
         a relation change, a leader election, or other, so call `_configure` to check
@@ -135,8 +130,7 @@ class GrafanaCharm(CharmBase):
         self._configure(event)
 
     def _on_grafana_source_changed(self, event: GrafanaSourceEvents) -> None:
-        """
-        When a grafana-source is added or modified, update the config
+        """When a grafana-source is added or modified, update the config.
 
         Args:
             event: a :class:`GrafanaSourceEvents` instance sent from the consumer
@@ -149,7 +143,8 @@ class GrafanaCharm(CharmBase):
         self.unit.status = MaintenanceStatus("Application is terminating.")
 
     def _configure(self, event: CharmEvents) -> None:
-        """
+        """Configure Grafana.
+
         Generate configuration files and check the sums against what is
         already stored in the charm. If either the base Grafana config
         or the datasource config differs, restart Grafana.
@@ -160,9 +155,7 @@ class GrafanaCharm(CharmBase):
         # Generate a new base config and see if it differs from what we have.
         # If it does, store it and signal that we should restart Grafana
         grafana_config_ini = self._generate_grafana_config()
-        config_ini_hash = hashlib.sha256(
-            str(grafana_config_ini).encode("utf-8")
-        ).hexdigest()
+        config_ini_hash = hashlib.sha256(str(grafana_config_ini).encode("utf-8")).hexdigest()
         if not self.grafana_config_ini_hash == config_ini_hash:
             self.grafana_config_ini_hash = config_ini_hash
             self._update_grafana_config_ini(grafana_config_ini)
@@ -172,9 +165,7 @@ class GrafanaCharm(CharmBase):
 
         # Do the same thing for datasources
         grafana_datasources = self._generate_datasource_config()
-        datasources_hash = hashlib.sha256(
-            str(grafana_datasources).encode("utf-8")
-        ).hexdigest()
+        datasources_hash = hashlib.sha256(str(grafana_datasources).encode("utf-8")).hexdigest()
         if not self.grafana_datasources_hash == datasources_hash:
             self.grafana_datasources_hash = datasources_hash
             self._update_datasource_config(grafana_datasources)
@@ -186,18 +177,14 @@ class GrafanaCharm(CharmBase):
             self.restart_grafana()
 
     def _update_datasource_config(self, config: str) -> None:
-        """
-        Write an updated datasource configuration file to the
-        Pebble container if necessary.
+        """Write an updated datasource configuration file to the Pebble container if necessary.
 
         Args:
             config: A :str: containing the datasource configuraiton
         """
         container = self.unit.get_container(self.name)
 
-        datasources_path = os.path.join(
-            DATASOURCE_PATH, "datasources", "datasources.yaml"
-        )
+        datasources_path = os.path.join(DATASOURCE_PATH, "datasources", "datasources.yaml")
         try:
             container.push(datasources_path, config)
         except ConnectionError:
@@ -206,9 +193,7 @@ class GrafanaCharm(CharmBase):
             )
 
     def _update_grafana_config_ini(self, config: str) -> None:
-        """
-        Write an updated Grafana configuration file to the
-        Pebble container if necessary
+        """Write an updated Grafana configuration file to the Pebble container if necessary.
 
         Args:
             config: A :str: containing the datasource configuraiton
@@ -222,7 +207,7 @@ class GrafanaCharm(CharmBase):
 
     @property
     def has_peers(self) -> bool:
-        """Check whether or nto there are any other Grafanas as peers"""
+        """Check whether or nto there are any other Grafanas as peers."""
         rel = self.model.get_relation(PEER)
         return len(rel.units) > 0 if rel is not None else False
 
@@ -230,6 +215,11 @@ class GrafanaCharm(CharmBase):
     # DASHBOARD IMPORT
     ###########################
     def init_dashboard_provisioning(self, dashboard_path: str):
+        """Initialise the provisioning of Grafana dashboards.
+
+        Args:
+            dashboard_path: str; A file path to the dashboard to provision
+        """
         logger.info("Initializing dashboard provisioning path")
         container = self.unit.get_container(self.name)
 
@@ -256,7 +246,7 @@ class GrafanaCharm(CharmBase):
                 )
 
     def _on_dashboards_changed(self, _) -> None:
-        """Handle dashboard events"""
+        """Handle dashboard events."""
         container = self.unit.get_container(self.name)
         dashboard_path = os.path.join(DATASOURCE_PATH, "dashboards")
 
@@ -270,17 +260,13 @@ class GrafanaCharm(CharmBase):
             logger.warning("Could not list dashboards. Pebble shutting down?")
 
         for dashboard in self.dashboard_provider.dashboards:
-            dash = zlib.decompress(
-                base64.b64decode(dashboard["dashboard"].encode())
-            ).decode()
+            dash = zlib.decompress(base64.b64decode(dashboard["dashboard"].encode())).decode()
             name = "{}_juju.json".format(dashboard["target"])
 
             dashboard_path = os.path.join(dashboard_path, name)
             existing_dashboards[dashboard_path] = True
 
-            logger.info(
-                "Newly created dashboard will be saved at: {}".format(dashboard_path)
-            )
+            logger.info("Newly created dashboard will be saved at: {}".format(dashboard_path))
             container.push(dashboard_path, dash, make_dirs=True)
 
         for f, known in existing_dashboards.items():
@@ -313,15 +299,12 @@ class GrafanaCharm(CharmBase):
 
         # Get required information
         database_fields = {
-            field: event.relation.data[event.app].get(field)
-            for field in REQUIRED_DATABASE_FIELDS
+            field: event.relation.data[event.app].get(field) for field in REQUIRED_DATABASE_FIELDS
         }
 
         # if any required fields are missing, warn the user and return
         missing_fields = [
-            field
-            for field in REQUIRED_DATABASE_FIELDS
-            if database_fields.get(field) is None
+            field for field in REQUIRED_DATABASE_FIELDS if database_fields.get(field) is None
         ]
         if len(missing_fields) > 0:
             raise SourceFieldsMissingError(
@@ -331,17 +314,14 @@ class GrafanaCharm(CharmBase):
 
         # add the new database relation data to the datastore
         self._stored.database.update(
-            {
-                field: value
-                for field, value in database_fields.items()
-                if value is not None
-            }
+            {field: value for field, value in database_fields.items() if value is not None}
         )
 
         self._configure(event)
 
     def _on_database_broken(self, event: RelationBrokenEvent) -> None:
         """Removes database connection info from datastore.
+
         We are guaranteed to only have one DB connection, so clearing
         datastore.database is all we need for the change to be propagated
         to the Pebble container.
@@ -360,7 +340,8 @@ class GrafanaCharm(CharmBase):
         self._configure(event)
 
     def _generate_grafana_config(self) -> str:
-        """
+        """Generate a database configuration for Grafana.
+
         For now, this only creates database information, since everything else
         can be set in ENV variables, but leave for expansion later so we can
         hide auth secrets
@@ -368,9 +349,11 @@ class GrafanaCharm(CharmBase):
         return self._generate_database_config() if self.has_db else ""
 
     def _generate_database_config(self) -> str:
-        """
-        Returns a :str: containing the required database information to
-        be stubbed into the config file
+        """Generate a database configuration.
+
+        Returns:
+            A string containing the required database information to be stubbed into the config
+            file.
         """
         db_config = self._stored.database
         config_ini = configparser.ConfigParser()
@@ -408,14 +391,12 @@ class GrafanaCharm(CharmBase):
     #####################################
 
     def _on_pebble_ready(self, event) -> None:
-        """
-        When Pebble is ready, start everything up
-        """
+        """When Pebble is ready, start everything up."""
         self._stored.pebble_ready = True
         self._configure(event)
 
     def restart_grafana(self) -> None:
-        """Restart the pebble container"""
+        """Restart the pebble container."""
         layer = self._build_layer()
 
         try:
@@ -438,7 +419,7 @@ class GrafanaCharm(CharmBase):
             )
 
     def _build_layer(self) -> Layer:
-        """Construct the pebble layer information"""
+        """Construct the pebble layer information."""
         # Placeholder for when we add "proper" mysql support for HA
         dbinfo = {"GF_DATABASE_TYPE": "sqlite3"}
 
@@ -476,13 +457,17 @@ class GrafanaCharm(CharmBase):
 
     @property
     def build_info(self) -> dict:
-        """Returns information about the running Grafana service"""
+        """Returns information about the running Grafana service."""
         return self.grafana_service.build_info
 
     def _generate_datasource_config(self) -> str:
-        """
-        Template out a Grafana datasource config from the sources (and
-        removed sources) the consumer knows about, and dump it to YAML
+        """Template out a Grafana datasource config.
+
+        Template using the sources (and removed sources) the consumer knows about, and dump it to
+        YAML.
+
+        Returns:
+            A a string-dumped YAML config for the datasources
         """
         # Boilerplate for the config file
         datasources_dict = {"apiVersion": 1, "datasources": [], "deleteDatasources": []}

--- a/src/grafana_server.py
+++ b/src/grafana_server.py
@@ -12,13 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+"""A module used for interacting with a running Grafana instance."""
+
 import json
+
 import urllib3
 
 
 class Grafana:
+    """A class that represents a running Grafana instance."""
+
     def __init__(self, host: str, port: int) -> None:
-        """A class to bring up and check a Grafana serverr
+        """A class to bring up and check a Grafana server.
 
         Args:
             host: a :str: which indicates the hostname
@@ -31,18 +36,16 @@ class Grafana:
 
     @property
     def is_ready(self) -> bool:
-        """Checks whether the Grafana server is up and running yet
+        """Checks whether the Grafana server is up and running yet.
 
         Returns:
             :bool: indicating whether or not the server is ready
         """
-
         return True if self.build_info.get("database", None) == "ok" else False
 
     @property
     def build_info(self) -> dict:
-        """
-        A convenience method which queries the API to see whether Grafana is really ready
+        """A convenience method which queries the API to see whether Grafana is really ready.
 
         Returns:
             Empty :dict: if it is not up, otherwise a dict containing basic API health

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1,13 +1,14 @@
-# Copyright 2020 Ryan Barry
+# Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import hashlib
-import unittest
-import yaml
 import json
-
+import unittest
 from unittest.mock import patch
+
+import yaml
 from ops.testing import Harness
+
 from charm import GrafanaCharm
 
 MINIMAL_CONFIG = {"grafana-image-path": "grafana/grafana", "port": 3000}
@@ -123,9 +124,7 @@ class TestCharm(unittest.TestCase):
         )
 
         config = push.call_args[0]
-        self.assertEqual(
-            datasource_config(config).get("datasources"), BASIC_DATASOURCES
-        )
+        self.assertEqual(datasource_config(config).get("datasources"), BASIC_DATASOURCES)
 
     @patch("ops.testing._TestingPebbleClient.push")
     def test_datasource_config_is_updated_by_grafana_source_removal(self, push):
@@ -141,9 +140,7 @@ class TestCharm(unittest.TestCase):
         )
 
         config = push.call_args[0]
-        self.assertEqual(
-            datasource_config(config).get("datasources"), BASIC_DATASOURCES
-        )
+        self.assertEqual(datasource_config(config).get("datasources"), BASIC_DATASOURCES)
 
         rel = self.harness.charm.framework.model.get_relation("grafana-source", rel_id)
         self.harness.charm.on["grafana-source"].relation_departed.emit(rel)

--- a/tests/test_dashboard_consumer.py
+++ b/tests/test_dashboard_consumer.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import base64
 import json
 import unittest
@@ -10,6 +11,7 @@ from unittest.mock import patch
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
+
 from lib.charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardConsumer
 
 if "unittest.util" in __import__("sys").modules:
@@ -84,9 +86,7 @@ class TestDashboardConsumer(unittest.TestCase):
         self.harness.add_relation_unit(mon_rel_id, "monitoring/0")
         self.harness.charm.consumer.add_dashboard(DASHBOARD_TMPL)
         data = json.loads(
-            self.harness.get_relation_data(rel_id, self.harness.model.app.name)[
-                "dashboards"
-            ]
+            self.harness.get_relation_data(rel_id, self.harness.model.app.name)["dashboards"]
         )
         return_data = {
             "monitoring_identifier": "testing_abcdefgh-1234_monitoring",
@@ -107,9 +107,7 @@ class TestDashboardConsumer(unittest.TestCase):
         self.harness.add_relation_unit(mon_rel_id, "monitoring/0")
         self.harness.charm.consumer.add_dashboard(DASHBOARD_TMPL)
         data = json.loads(
-            self.harness.get_relation_data(rel_id, self.harness.model.app.name)[
-                "dashboards"
-            ]
+            self.harness.get_relation_data(rel_id, self.harness.model.app.name)["dashboards"]
         )
         return_data = {
             "monitoring_identifier": "testing_abcdefgh-1234_monitoring",
@@ -143,9 +141,7 @@ class TestDashboardConsumer(unittest.TestCase):
         mon_rel_id = self.harness.add_relation("monitoring", "consumer")
         self.harness.add_relation_unit(mon_rel_id, "monitoring/0")
         data = json.loads(
-            self.harness.get_relation_data(rel_id, self.harness.model.app.name)[
-                "dashboards"
-            ]
+            self.harness.get_relation_data(rel_id, self.harness.model.app.name)["dashboards"]
         )
         return_data = {
             "monitoring_identifier": "testing_abcdefgh-1234_monitoring",
@@ -171,9 +167,7 @@ class TestDashboardConsumer(unittest.TestCase):
         self.harness.add_relation_unit(mon_rel_id, "monitoring/0")
         self.harness.remove_relation(mon_rel_id)
         data = json.loads(
-            self.harness.get_relation_data(rel_id, self.harness.model.app.name)[
-                "dashboards"
-            ]
+            self.harness.get_relation_data(rel_id, self.harness.model.app.name)["dashboards"]
         )
         return_data = {
             "monitoring_identifier": "testing_abcdefgh-1234_monitoring",

--- a/tests/test_dashboard_provider.py
+++ b/tests/test_dashboard_provider.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import base64
 import copy
 import json
@@ -11,6 +12,7 @@ from unittest.mock import patch
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
+
 from lib.charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 
 if "unittest.util" in __import__("sys").modules:
@@ -62,9 +64,7 @@ class ProviderCharm(CharmBase):
         self.grafana_provider = GrafanaDashboardProvider(
             self, "grafana-dashboard", "grafana", self.version
         )
-        self.framework.observe(
-            self.grafana_provider.on.dashboards_changed, self.dashboard_events
-        )
+        self.framework.observe(self.grafana_provider.on.dashboards_changed, self.dashboard_events)
 
     def dashboard_events(self, _):
         self._stored.dashboard_events += 1
@@ -88,6 +88,7 @@ class TestDashboardProvider(unittest.TestCase):
 
     def setup_charm_relations(self, multi=False):
         """Create relations used by test cases.
+
         Args:
             multi: a boolean indicating if multiple relations must be
             created.
@@ -169,14 +170,10 @@ class TestDashboardProvider(unittest.TestCase):
         )
 
         data = json.loads(
-            self.harness.get_relation_data(rels[0], self.harness.model.app.name)[
-                "event"
-            ]
+            self.harness.get_relation_data(rels[0], self.harness.model.app.name)["event"]
         )
         self.assertEqual(data["valid"], False)
-        self.assertIn(
-            "Cannot add Grafana dashboard. Template is not valid Jinja", data["errors"]
-        )
+        self.assertIn("Cannot add Grafana dashboard. Template is not valid Jinja", data["errors"])
 
     def test_provider_error_on_invalidation(self):
         self.assertEqual(len(self.harness.charm.grafana_provider._stored.dashboards), 0)
@@ -197,9 +194,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
 
         data = json.loads(
-            self.harness.get_relation_data(rels[0], self.harness.model.app.name)[
-                "event"
-            ]
+            self.harness.get_relation_data(rels[0], self.harness.model.app.name)["event"]
         )
         self.assertEqual(data["valid"], False)
         self.assertIn("Doesn't matter", data["errors"])
@@ -220,9 +215,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
 
         data = json.loads(
-            self.harness.get_relation_data(rels[0], self.harness.model.app.name)[
-                "event"
-            ]
+            self.harness.get_relation_data(rels[0], self.harness.model.app.name)["event"]
         )
         self.assertEqual(data["valid"], False)
         self.assertIn("No configured datasources", data["errors"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,9 +3,9 @@
 
 import json
 import unittest
-import urllib3
-
 from unittest.mock import patch
+
+import urllib3
 
 from src.grafana_server import Grafana
 
@@ -34,9 +34,7 @@ class TestServer(unittest.TestCase):
 
     @patch("src.grafana_server.urllib3.PoolManager.request")
     def test_grafana_server_max_retry_test(self, request):
-        request.side_effect = urllib3.exceptions.MaxRetryError(
-            None, "/", "We shouldn't get here"
-        )
+        request.side_effect = urllib3.exceptions.MaxRetryError(None, "/", "We shouldn't get here")
         build_info = self.grafana.build_info
         self.assertEqual(build_info, {})
 

--- a/tests/test_source_consumer.py
+++ b/tests/test_source_consumer.py
@@ -1,11 +1,13 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import unittest
 from unittest.mock import patch
 
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
+
 from lib.charms.grafana_k8s.v0.grafana_source import GrafanaSourceConsumer
 
 SOURCE_DATA = {
@@ -63,9 +65,7 @@ class TestSourceConsumer(unittest.TestCase):
             "bind-addresses": [
                 {
                     "interface-name": "eth0",
-                    "addresses": [
-                        {"hostname": "grafana-tester-0", "value": bind_address}
-                    ],
+                    "addresses": [{"hostname": "grafana-tester-0", "value": bind_address}],
                 }
             ]
         }
@@ -84,9 +84,7 @@ class TestSourceConsumer(unittest.TestCase):
             "bind-addresses": [
                 {
                     "interface-name": "eth0",
-                    "addresses": [
-                        {"hostname": "grafana-tester-0", "value": bind_address}
-                    ],
+                    "addresses": [{"hostname": "grafana-tester-0", "value": bind_address}],
                 }
             ]
         }

--- a/tests/test_source_provider.py
+++ b/tests/test_source_provider.py
@@ -2,15 +2,14 @@
 # See LICENSE file for licensing details.
 
 import json
-import pytest
 import unittest
 
+import pytest
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
-from lib.charms.grafana_k8s.v0.grafana_source import (
-    GrafanaSourceProvider,
-)
+
+from lib.charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 
 SOURCE_DATA = {
     "model": "test-model",
@@ -44,9 +43,7 @@ class GrafanaCharm(CharmBase):
         self.grafana_provider = GrafanaSourceProvider(
             self, "grafana-source", "grafana", self.version
         )
-        self.framework.observe(
-            self.grafana_provider.on.sources_changed, self.source_events
-        )
+        self.framework.observe(self.grafana_provider.on.sources_changed, self.source_events)
         self.framework.observe(
             self.grafana_provider.on.sources_to_delete_changed,
             self.source_delete_events,
@@ -76,6 +73,7 @@ class TestSourceProvider(unittest.TestCase):
 
     def setup_charm_relations(self, multi=False):
         """Create relations used by test cases.
+
         Args:
             multi: a boolean indicating if multiple relations must be
             created.


### PR DESCRIPTION
When #24 is landed, the charm will fail to lint correctly.

This PR fixes those lint issues, and mostly makes changes to docstrings/whitespace/formatting.