### PR TITLE
Remove ops.relation, swap requires and provides in metadata

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -101,7 +101,7 @@ class GrafanaDashboardConsumer(Object):
         by instantiating a :class:`GrafanaDashboardConsumer` object and
         adding its datasources as follows:
 
-            self.grafana = GrafanaConsumer(self, "grafana-source", {"grafana-source"}: ">=2.0"})
+            self.grafana = GrafanaConsumer(self, "grafana-source")
             self.grafana.add_dashboard(data: str)
 
         Args:
@@ -110,20 +110,11 @@ class GrafanaDashboardConsumer(Object):
                 `self` in the instantiating class.
             name: a :string: name of the relation between `charm`
                 the Grafana charmed service.
-            consumes: a :dict: of acceptable monitoring service
-                providers. The keys of the dictionary are :string:
-                names of grafana source service providers. Typically,
-                this is `grafana-source`. The values of the dictionary
-                are corresponding minimal acceptable semantic versions
-                for the service.
             event_relation: a :string: name of the relation between
                 the charmed service and some provider which is required
                 for dashboard validity. When events on `event_relation`
                 occur, this consumer library will invalidate or
                 restore the dashboard
-            multi: an optional (default `False`) flag to indicate if
-                this object should support interacting with multiple
-                service providers.
         """
         super().__init__(charm, name)
         self.charm = charm
@@ -330,14 +321,6 @@ class GrafanaDashboardProvider(Object):
                 instance of the Grafana dashboard service.
             name: string name of the relation that is provides the
                 Grafana dashboard service.
-            service: string name of service provided. This is used by
-                :class:`GrafanaDashboardProvider` to validate this service as
-                acceptable. Hence the string name must match one of the
-                acceptable service names in the :class:`GrafanaDashboardProvider`s
-                `consumes` argument. Typically this string is just "grafana".
-            version: a string providing the semantic version of the Grafana
-                dashboard being provided.
-
         """
         super().__init__(charm, name)
         self.charm = charm
@@ -361,7 +344,7 @@ class GrafanaDashboardProvider(Object):
         If there are changes in relations between Grafana dashboard providers
         and consumers, this event handler (if the unit is the leader) will
         get data for an incoming grafana-dashboard relation through a
-        :class:`GrafanaDashboardssChanged` event, and make the relation data
+        :class:`GrafanaDashboardsChanged` event, and make the relation data
         is available in the app's datastore object. The Grafana charm can
         then respond to the event to update its configuration
         """

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -95,12 +95,6 @@ class GrafanaSourceConsumer(Object):
                 `self` in the instantiating class.
             name: a :string: name of the relation between `charm`
                 the Grafana charmed service.
-            consumes: a :dict: of acceptable monitoring service
-                providers. The keys of the dictionary are :string:
-                names of grafana source service providers. Typically,
-                this is `grafana-source`. The values of the dictionary
-                are corresponding minimal acceptable semantic versions
-                for the service.
             refresh_event: a :class:`CharmEvents` event on which the IP
                 address should be refreshed in case of pod or
                 machine/VM restart.
@@ -108,9 +102,6 @@ class GrafanaSourceConsumer(Object):
                 required for Grafana configuration
             source_port: an optional (default `9090`) source port
                 required for Grafana configuration
-            multi: an optional (default `False`) flag to indicate if
-                this object should support interacting with multiple
-                service providers.
         """
         super().__init__(charm, name)
         self.charm = charm
@@ -175,13 +166,6 @@ class GrafanaSourceProvider(Object):
                 instance of the Grafana source service.
             name: string name of the relation that is provides the
                 Grafana source service.
-            service: string name of service provided. This is used by
-                :class:`GrafanaSourceProvider` to validate this service as
-                acceptable. Hence the string name must match one of the
-                acceptable service names in the :class:`GrafanaSourceProvider`s
-                `consumes` argument. Typically this string is just "grafana".
-            version: a string providing the semantic version of the Grafana
-                source being provided.
         """
         super().__init__(charm, name)
         self.name = name

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -8,9 +8,8 @@ import logging
 from typing import Dict, List, Optional
 
 from ops.charm import CharmBase, CharmEvents, RelationDepartedEvent, RelationJoinedEvent
-from ops.framework import EventBase, EventSource, ObjectEvents, StoredState
+from ops.framework import EventBase, EventSource, Object, ObjectEvents, StoredState
 from ops.model import Relation
-from ops.relation import ConsumerBase, ProviderBase
 
 # The unique Charmhub library identifier, never change it
 LIBID = "974705adb86f40228298156e34b460dc"
@@ -59,7 +58,7 @@ class GrafanaSourceEvents(ObjectEvents):
     sources_to_delete_changed = EventSource(GrafanaSourcesChanged)
 
 
-class GrafanaSourceConsumer(ConsumerBase):
+class GrafanaSourceConsumer(Object):
     """A consumer object for Grafana datasources."""
 
     _stored = StoredState()
@@ -68,11 +67,9 @@ class GrafanaSourceConsumer(ConsumerBase):
         self,
         charm: CharmBase,
         name: str,
-        consumes: dict,
         refresh_event: CharmEvents,
         source_type: Optional[str] = "prometheus",
         source_port: Optional[str] = "9090",
-        multi: Optional[bool] = False,
     ) -> None:
         """Construct a Grafana charm client.
 
@@ -115,9 +112,9 @@ class GrafanaSourceConsumer(ConsumerBase):
                 this object should support interacting with multiple
                 service providers.
         """
-        super().__init__(charm, name, consumes, multi)
-
+        super().__init__(charm, name)
         self.charm = charm
+        self.name = name
         events = self.charm.on[name]
 
         self._source_type = source_type
@@ -164,15 +161,13 @@ class GrafanaSourceConsumer(ConsumerBase):
             )
 
 
-class GrafanaSourceProvider(ProviderBase):
+class GrafanaSourceProvider(Object):
     """A provider object for working with Grafana datasources."""
 
     on = GrafanaSourceEvents()
     _stored = StoredState()
 
-    def __init__(
-        self, charm: CharmBase, name: str, service: str, version: Optional[str] = None
-    ) -> None:
+    def __init__(self, charm: CharmBase, name: str) -> None:
         """A Grafana based Monitoring service consumer.
 
         Args:
@@ -188,7 +183,8 @@ class GrafanaSourceProvider(ProviderBase):
             version: a string providing the semantic version of the Grafana
                 source being provided.
         """
-        super().__init__(charm, name, service, version)
+        super().__init__(charm, name)
+        self.name = name
         self.charm = charm
         events = self.charm.on[name]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,14 +24,14 @@ containers:
 provides:
   grafana:
     interface: grafana
-  grafana-source:
-    interface: grafana_datasource
-  grafana-dashboard:
-    interface: grafana_dashboard
 storage:
   database:
     type: filesystem
 requires:
+  grafana-source:
+    interface: grafana_datasource
+  grafana-dashboard:
+    interface: grafana_dashboard
   database:
     interface: db
     limit: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 git+https://github.com/canonical/operator/#egg=ops
-semantic_version
 pyyaml
 urllib3
 jinja2

--- a/src/charm.py
+++ b/src/charm.py
@@ -93,7 +93,7 @@ class GrafanaCharm(CharmBase):
         self.framework.observe(self.on.stop, self._on_stop)
 
         # -- grafana_source relation observations
-        self.source_provider = GrafanaSourceProvider(self, "grafana-source", "grafana", VERSION)
+        self.source_provider = GrafanaSourceProvider(self, "grafana-source")
         self.framework.observe(
             self.source_provider.on.sources_changed,
             self._on_grafana_source_changed,
@@ -104,9 +104,7 @@ class GrafanaCharm(CharmBase):
         )
 
         # -- grafana_dashboard relation observations
-        self.dashboard_provider = GrafanaDashboardProvider(
-            self, "grafana-dashboard", "grafana", VERSION
-        )
+        self.dashboard_provider = GrafanaDashboardProvider(self, "grafana-dashboard")
         self.framework.observe(
             self.dashboard_provider.on.dashboards_changed, self._on_dashboards_changed
         )
@@ -410,7 +408,6 @@ class GrafanaCharm(CharmBase):
                 self.container.start(self.name)
                 logger.info("Restarted grafana-k8s")
 
-            self.source_provider.ready()
             self.unit.status = ActiveStatus()
         except ConnectionError:
             logger.error(

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,7 +60,6 @@ VALID_DATABASE_TYPES = {"mysql", "postgres", "sqlite3"}
 
 CONFIG_PATH = "/etc/grafana/grafana-config.ini"
 DATASOURCE_PATH = "/etc/grafana/provisioning"
-VERSION = "2.0.0"
 PEER = "grafana-peers"
 
 

--- a/tests/test_dashboard_consumer.py
+++ b/tests/test_dashboard_consumer.py
@@ -39,7 +39,7 @@ class ConsumerCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.consumer = GrafanaDashboardConsumer(
-            self, "grafana-dashboard", {"grafana": ">=1.0"}, event_relation="monitoring"
+            self, "grafana-dashboard", event_relation="monitoring"
         )
 
         self._stored.set_default(valid_events=0)  # available data sources

--- a/tests/test_dashboard_provider.py
+++ b/tests/test_dashboard_provider.py
@@ -60,9 +60,7 @@ class ProviderCharm(CharmBase):
         super().__init__(*args)
         self._stored.set_default(dashboard_events=0)
 
-        self.grafana_provider = GrafanaDashboardProvider(
-            self, "grafana-dashboard", "grafana", self.version
-        )
+        self.grafana_provider = GrafanaDashboardProvider(self, "grafana-dashboard")
         self.framework.observe(self.grafana_provider.on.dashboards_changed, self.dashboard_events)
 
     def dashboard_events(self, _):

--- a/tests/test_source_consumer.py
+++ b/tests/test_source_consumer.py
@@ -34,7 +34,6 @@ class ConsumerCharm(CharmBase):
         self.consumer = GrafanaSourceConsumer(
             self,
             "grafana-source",
-            {"grafana": ">=1.v0"},
             refresh_event=self.on.grafana_tester_pebble_ready,
         )
 

--- a/tests/test_source_provider.py
+++ b/tests/test_source_provider.py
@@ -39,9 +39,7 @@ class GrafanaCharm(CharmBase):
         self._stored.set_default(source_events=0)  # available data sources
         self._stored.set_default(source_delete_events=0)
 
-        self.grafana_provider = GrafanaSourceProvider(
-            self, "grafana-source", "grafana", self.version
-        )
+        self.grafana_provider = GrafanaSourceProvider(self, "grafana-source")
         self.framework.observe(self.grafana_provider.on.sources_changed, self.source_events)
         self.framework.observe(
             self.grafana_provider.on.sources_to_delete_changed,


### PR DESCRIPTION
Dylan's intuition was correct -- dumping `ops.relation` from the tree, changing the parent to `Object`, and removing the args from the old parent class works as expected.

Only used `.ready()` in one place in the charm