### PR TITLE
Prevent breaking Jinja2 3x changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/canonical/operator/#egg=ops
 pyyaml
 urllib3
-jinja2
+jinja2 < 3.0.0


### PR DESCRIPTION
Due to https://github.com/pallets/jinja/issues/1496, we cannot use the latest Jinja2 packages inside the operator. The breaking change was introduced in Jinja2's 3x branch, and this change pins the `jinja2` dependency to the latest 2x release.